### PR TITLE
Fix hardcoded executable path; Fixes #1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/PromiseKit/Foundation", from: "3.3.0"),
-        .package(url: "https://github.com/mxcl/Path.swift", from: "0.15.1"),
+        .package(url: "https://github.com/mxcl/Path.swift", from: "0.16.0"),
         .package(url: "https://github.com/mxcl/Version", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Also allow executable name to be different in newly downloaded version.