### PR TITLE
[codex] Prompt via Finder for protected installs

### DIFF
--- a/AppUpdater.swift
+++ b/AppUpdater.swift
@@ -624,9 +624,10 @@ enum InstallerHelper {
     prepared_bundle="$(dirname "$staged_bundle")/$installed_name"
     deadline=$(( $(date +%s) + 300 ))
 
+    trap 'rm -rf "$staging_directory"' EXIT
+
     while kill -0 "$pid" 2>/dev/null; do
         if [ "$(date +%s)" -ge "$deadline" ]; then
-            rm -rf "$staging_directory"
             exit 1
         fi
         sleep 0.2
@@ -656,8 +657,6 @@ enum InstallerHelper {
     else
         /usr/bin/open "$installed_bundle"
     fi
-
-    rm -rf "$staging_directory"
     """
 }
 

--- a/AppUpdater.swift
+++ b/AppUpdater.swift
@@ -619,6 +619,9 @@ enum InstallerHelper {
     installed_bundle="$3"
     executable="$4"
     staging_directory="$5"
+    installed_name="$(basename "$installed_bundle")"
+    installed_parent="$(dirname "$installed_bundle")"
+    prepared_bundle="$(dirname "$staged_bundle")/$installed_name"
     deadline=$(( $(date +%s) + 300 ))
 
     while kill -0 "$pid" 2>/dev/null; do
@@ -629,8 +632,24 @@ enum InstallerHelper {
         sleep 0.2
     done
 
-    rm -rf "$installed_bundle"
-    mv "$staged_bundle" "$installed_bundle"
+    if [ "$staged_bundle" != "$prepared_bundle" ]; then
+        rm -rf "$prepared_bundle"
+        mv "$staged_bundle" "$prepared_bundle"
+        staged_bundle="$prepared_bundle"
+    fi
+
+    if [ -w "$installed_parent" ] && { [ ! -e "$installed_bundle" ] || [ -w "$installed_bundle" ]; }; then
+        rm -rf "$installed_bundle"
+        mv "$staged_bundle" "$installed_bundle"
+    else
+        /usr/bin/osascript - "$staged_bundle" "$installed_parent" <<'APPLESCRIPT'
+    on run argv
+        set stagedBundle to POSIX file (item 1 of argv) as alias
+        set destinationFolder to POSIX file (item 2 of argv) as alias
+        tell application "Finder" to move stagedBundle to destinationFolder with replacing
+    end run
+    APPLESCRIPT
+    fi
 
     if [ -x "$executable" ]; then
         "$executable" >/dev/null 2>&1 &

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ asset and stages verified updates for your app to install explicitly.
 
 * Your app owns the user experience for asking to quit and install an update.
 * Assets must be named: `\(reponame)-\(semanticVersion).ext`.
-* Will not work if App is installed as a root user.
+* Protected install locations may require a Finder authentication prompt.
 
 ## Features
 

--- a/Tests/AppUpdaterTests/AppUpdaterTests.swift
+++ b/Tests/AppUpdaterTests/AppUpdaterTests.swift
@@ -729,7 +729,60 @@ final class AppUpdaterTests: XCTestCase {
         XCTAssertTrue(script.contains("installed_bundle=\"$3\""))
         XCTAssertTrue(script.contains("executable=\"$4\""))
         XCTAssertTrue(script.contains("deadline=$(( $(date +%s) + 300 ))"))
+        XCTAssertTrue(script.contains("if [ -w \"$installed_parent\" ] && { [ ! -e \"$installed_bundle\" ] || [ -w \"$installed_bundle\" ]; }; then"))
+        XCTAssertTrue(script.contains("/usr/bin/osascript - \"$staged_bundle\" \"$installed_parent\""))
+        XCTAssertTrue(script.contains("tell application \"Finder\" to move stagedBundle to destinationFolder with replacing"))
         XCTAssertEqual(permissions, 0o700)
+    }
+
+    func testInstallerHelperInstallsIntoWritableDirectory() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let stagingDirectory = root.appendingPathComponent("staging", isDirectory: true)
+        let installedParent = root.appendingPathComponent("Applications", isDirectory: true)
+        let stagedBundle = stagingDirectory.appendingPathComponent("AppUpdater.app", isDirectory: true)
+        let installedBundle = installedParent.appendingPathComponent("AppUpdater.app", isDirectory: true)
+        let executable = installedBundle
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent("AppUpdater")
+        let stagedExecutable = stagedBundle
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent("AppUpdater")
+
+        try FileManager.default.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: installedParent, withIntermediateDirectories: true)
+        try makeApp(named: "AppUpdater.app", in: stagingDirectory)
+        try makeApp(named: "AppUpdater.app", in: installedParent)
+        try "new".write(to: stagedBundle.appendingPathComponent("marker"), atomically: true, encoding: .utf8)
+        try "old".write(to: installedBundle.appendingPathComponent("marker"), atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nexit 0\n".write(to: stagedExecutable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: stagedExecutable.path)
+
+        let finishedProcess = Process()
+        finishedProcess.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try finishedProcess.run()
+        finishedProcess.waitUntilExit()
+
+        let scriptURL = try InstallerHelper.writeScript(in: stagingDirectory)
+        _ = try await ProcessRunner.run(
+            scriptURL,
+            arguments: [
+                "\(finishedProcess.processIdentifier)",
+                stagedBundle.path,
+                installedBundle.path,
+                executable.path,
+                stagingDirectory.path,
+            ]
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stagingDirectory.path))
+        XCTAssertEqual(
+            try String(contentsOf: installedBundle.appendingPathComponent("marker"), encoding: .utf8),
+            "new"
+        )
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- fallback to Finder replacement when the installed app location or bundle is not writable
- keep the existing direct move path for writable installs
- update the caveat docs and add a helper execution test

## Root cause

The installer helper always used `rm -rf` plus `mv`, so protected installs such as non-admin `/Applications` or root-owned app bundles failed instead of presenting a macOS authentication prompt.

## Validation

- `swift test`